### PR TITLE
Prevent some assembler breakages

### DIFF
--- a/hera/__init__.py
+++ b/hera/__init__.py
@@ -1,1 +1,0 @@
-from . import main  # noqa: F401

--- a/hera/__main__.py
+++ b/hera/__main__.py
@@ -1,0 +1,2 @@
+from hera.main import main
+main()

--- a/hera/assembler.py
+++ b/hera/assembler.py
@@ -80,6 +80,7 @@ def assemble_and_print(program: Program, settings: Settings) -> None:
 
         with open(path + ".ldata", "w", encoding="ascii") as f:
             f.write(data)
+            f.write("\n")
 
 
 def bytes_to_hex(b: bytes) -> str:

--- a/hera/assembler.py
+++ b/hera/assembler.py
@@ -75,10 +75,12 @@ def assemble_and_print(program: Program, settings: Settings) -> None:
             path = settings.path
 
         with open(path + ".lcode", "w", encoding="ascii") as f:
+            f.write("v2.0 raw\n")
             f.write(code)
             f.write("\n")
 
         with open(path + ".ldata", "w", encoding="ascii") as f:
+            f.write("v2.0 raw\n")
             f.write(data)
             f.write("\n")
 

--- a/hera/op.py
+++ b/hera/op.py
@@ -1692,14 +1692,14 @@ class INTEGER(DataOperation):
       INTEGER is a data instruction.
     """
 
-    P = (I16,)
+    P = (I16_OR_LABEL,)
 
     def execute(self, vm):
         vm.store_memory(vm.dc, to_u16(self.args[0]))
         vm.dc += 1
 
     def assemble(self):
-        return bytes([self.args[0] & 0xFF00, self.args[0] & 0xFF])
+        return bytes([(self.args[0] & 0xFF00)//256, self.args[0] & 0xFF])
 
 
 class DSKIP(DataOperation):
@@ -1741,7 +1741,7 @@ class LP_STRING(DataOperation):
 
     def assemble(self):
         s = self.args[0]
-        length_bytes = [len(s) & 0xFF00, len(s) & 0xFF]
+        length_bytes = [(len(s) & 0xFF00)//256, len(s) & 0xFF]
         data_bytes = []
         for c in s:
             data_bytes.append(0)


### PR DESCRIPTION
* high byte of INTEGER constant and LP_STRING length shifted to byte range in their respective byte arrays, preventing a crash
* INTEGER modified to take an I16_OR_LABEL rather than just I16, to match the semantics of SET and to allow for preloaded vtables
* place "v2.0 raw" at the top of generated files to match Hassem
* place newline at end of ldata files like is done for lcode files
* use `__main__` instead of `__init__` to pull in main